### PR TITLE
Plotter issue occurs while a fields container contains several fields but that some are empty and ElementalNodal

### DIFF
--- a/ansys/dpf/core/plotter.py
+++ b/ansys/dpf/core/plotter.py
@@ -185,11 +185,11 @@ class Plotter:
 
         # pre-loop to get location and component count
         for field in fields_container:
-            #if len(field.data) != 0:
-            location = field.location
-            component_count = field.component_count
-            name = field.name.split("_")[0]
-            break
+            if len(field.data) != 0:
+                location = field.location
+                component_count = field.component_count
+                name = field.name.split("_")[0]
+                break
 
         if location == locations.nodal:
             mesh_location = mesh.nodes

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -99,7 +99,7 @@ Optional dependencies can be installed for specific usage:
 
 Compatibility
 ~~~~~~~~~~~~~
-As of 20201R2, DPF supports Windows 10 and CentOS 7 and newer.  For
+DPF supports Windows 10 and CentOS 7 and newer.  For
 more details, see `Ansys Platform Support <https://www.ansys.com/solutions/solutions-by-role/it-professionals/platform-support>`_.
 
 Other platforms may be supported by using DPF within a


### PR DESCRIPTION
Plotter issue occurs while a fields container contains several field (that are supposed to be elemental and so plottable) but for some optimization reason, some are still ElementalNodal and empty (as they are empty the process did not change their location while averaging). Then checking the location only when the field is not empty is a solution.