### PR TITLE
Versioning: warning product version

### DIFF
--- a/ansys/dpf/core/_version.py
+++ b/ansys/dpf/core/_version.py
@@ -5,4 +5,5 @@ version_info = 0, 3, 'dev0'
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))
 __ansys_version__ = "212"
+__ansys_consumer_version__ = "2021 R2"
 min_server_version = "2.0"

--- a/ansys/dpf/core/server.py
+++ b/ansys/dpf/core/server.py
@@ -134,6 +134,10 @@ def start_local_server(ip=LOCALHOST, port=DPF_DEFAULT_PORT,
     -------
     server : server.DpfServer
     """
+    from ansys.dpf.core._version import __ansys_consumer_version__
+    import warnings
+    warnings.warn(f"This version of ansys-dpf-core matches with an Ansys {__ansys_consumer_version__} product version.")
+    
     if ansys_path is None:
         ansys_path = os.environ.get('AWP_ROOT'+__ansys_version__, find_ansys())
     if ansys_path is None:


### PR DESCRIPTION
The aim of this PR is to add a warning while using dpf.start_local_server() to mention the consumer version of Ansys product that must be used. 

**Notes about what is already existing:** 
We do already check the DPF server version (since ansys-dpf-core.0.3.0) for few features. Moreover, this check can only be done once we are connected to the server.
We probably would like some backward compatibility that would prevent us to raise any error if the DPF server (directly related to the ansys consumer version) does not match with the python package version. 