### PR TITLE
Remove assert isinstance(cpos, CameraPosition) for plotting tests

### DIFF
--- a/ansys/dpf/core/field.py
+++ b/ansys/dpf/core/field.py
@@ -253,9 +253,6 @@ class Field(_FieldBase):
         >>> fields_container = disp.outputs.fields_container()
         >>> field = fields_container[0]
         >>> mesh.plot(field)
-        [(1.675707321585373, 1.675707321585373, 2.425707321585373),
-         (0.0, 0.0, 0.75),
-         (0.0, 0.0, 1.0)]
 
         Parameters
         ----------

--- a/ansys/dpf/core/meshed_region.py
+++ b/ansys/dpf/core/meshed_region.py
@@ -372,9 +372,6 @@ class MeshedRegion:
         >>> disp = model.results.displacement()
         >>> field = disp.outputs.fields_container()[0]
         >>> model.metadata.meshed_region.plot(field)
-        [(0.0729555495773441, 0.1029555495773441, 0.0729555495773441),
-         (0.015, 0.045, 0.015),
-         (0.0, 0.0, 1.0)]
         
         """
         pl = _DpfPlotter(self)

--- a/ansys/dpf/core/meshed_region.py
+++ b/ansys/dpf/core/meshed_region.py
@@ -330,9 +330,6 @@ class MeshedRegion:
         Plot this grid directly.
 
         >>> grid.plot()
-        [(0.0729555495773441, 0.1029555495773441, 0.0729555495773441),
-         (0.015, 0.045, 0.015),
-         (0.0, 0.0, 1.0)]
 
         Extract the surface mesh of this grid
 

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -38,7 +38,6 @@ def test_plotter_on_mesh(allkindofcomplexity):
     model = Model(allkindofcomplexity)
     pl = DpfPlotter(model.metadata.meshed_region)
     cpos = pl.plot_mesh()
-    assert isinstance(cpos, CameraPosition)
 
 
 @pytest.mark.skipif(not HAS_PYVISTA, reason='Please install pyvista')
@@ -55,7 +54,6 @@ def test_plotter_on_field(allkindofcomplexity):
     fields_container.add_label('time')
     fields_container.add_field({'time': 1}, field)
     cpos = pl.plot_contour(fields_container)
-    assert isinstance(cpos, CameraPosition)
 
 
 @pytest.mark.skipif(not HAS_PYVISTA, reason='Please install pyvista')
@@ -68,7 +66,6 @@ def test_plotter_on_fields_container_elemental(allkindofcomplexity):
     fc = avg_op.outputs.fields_container()
     pl = DpfPlotter(model.metadata.meshed_region)
     cpos = pl.plot_contour(fc)
-    assert isinstance(cpos, CameraPosition)
 
 
 @pytest.mark.skipif(not HAS_PYVISTA, reason='Please install pyvista')
@@ -81,7 +78,6 @@ def test_plotter_on_fields_container_nodal(allkindofcomplexity):
     fc = avg_op.outputs.fields_container()
     pl = DpfPlotter(model.metadata.meshed_region)
     cpos = pl.plot_contour(fc)
-    assert isinstance(cpos, CameraPosition)
     
 
 @pytest.mark.skipif(not HAS_PYVISTA, reason='Please install pyvista')


### PR DESCRIPTION
This is a requirement to get the CI working following updates in PyVista module. Plotting returns None unless return_camera=True in Plotter.show(). 